### PR TITLE
add proxy settings

### DIFF
--- a/invite_to_times.py
+++ b/invite_to_times.py
@@ -8,7 +8,15 @@ def invite_to_times():
     """invite all users to all 'times_XXX' channels"""
 
     if TOKEN:
-        sc = SlackClient(TOKEN)
+        if "HTTP_PROXY" in os.environ and "HTTPS_PROXY" in os.environ:
+            http = os.environ["HTTP_PROXY"]
+            https = os.environ["HTTP_PROXY"]
+            proxy = {"http": http, "https": https}
+            print("setting http proxy : " + http)
+            print("setting https proxy : " + https)
+            sc = SlackClient(TOKEN, proxy)
+        else:
+            sc = SlackClient(TOKEN)
 
         # get users
         users = sc.api_call("users.list")

--- a/invite_to_times.py
+++ b/invite_to_times.py
@@ -10,7 +10,7 @@ def invite_to_times():
     if TOKEN:
         if "HTTP_PROXY" in os.environ and "HTTPS_PROXY" in os.environ:
             http = os.environ["HTTP_PROXY"]
-            https = os.environ["HTTP_PROXY"]
+            https = os.environ["HTTPS_PROXY"]
             proxy = {"http": http, "https": https}
             print("setting http proxy : " + http)
             print("setting https proxy : " + https)


### PR DESCRIPTION
#3 

If HTTP_PROXY and HTTPS_PROXY in environment variables, set proxy for slackclient lib.

It may require slackclient version 1.0.6  or upper.
you should update slackclient using fokllowing command

`pip install -U slackclient`

only test on my PC